### PR TITLE
Remove static word in comment

### DIFF
--- a/frontend/src/auth/AuthService.js
+++ b/frontend/src/auth/AuthService.js
@@ -82,7 +82,7 @@ export default class AuthService {
     return new Date().getTime() < this.expiresAt
   }
 
-  // a static method to get the access token
+  // a method to get the access token
   getAuthToken () {
     return this.accessToken
   }


### PR DESCRIPTION
Since this method use `this`, we can't call this a static method